### PR TITLE
fix: 修复配置页面无法显示的问题 (#46)

### DIFF
--- a/src/main/java/DetSql/DetSql.java
+++ b/src/main/java/DetSql/DetSql.java
@@ -760,12 +760,13 @@ public class DetSql implements BurpExtension, ContextMenuItemsProvider{
                 tabbedPane1.addTab("CodeTool", new JPanel());
 
                 // Sync selected tab to content card
+                // Use fixed English keys regardless of tab title language
+                final String[] CARD_KEYS = {"DashBoard", "Config", "CodeTool"};
                 tabbedPane1.addChangeListener(e -> {
                     int idx = tabbedPane1.getSelectedIndex();
-                    if (idx >= 0) {
-                        String title = tabbedPane1.getTitleAt(idx);
+                    if (idx >= 0 && idx < CARD_KEYS.length) {
                         CardLayout cl = (CardLayout) contentCards.getLayout();
-                        cl.show(contentCards, title);
+                        cl.show(contentCards, CARD_KEYS[idx]);
                     }
                 });
 


### PR DESCRIPTION
## 🐛 问题描述

在 v3.0 版本中，当用户点击"配置"（Config）按钮时，配置页面无法显示，导致用户无法修改插件设置。

相关 Issue: #46

## 🔍 根本原因

CardLayout 在注册组件时使用英文 key `"Config"`，但由于国际化（i18n）功能，tab 标题会被翻译成中文 `"配置"`。原代码使用 tab 标题作为 CardLayout 的查找 key，导致无法匹配到正确的组件：

```java
// 原代码问题
String title = tabbedPane1.getTitleAt(idx);  // 中文环境下返回 "配置"
cl.show(contentCards, title);                // 查找 "配置" key 失败
```

**流程图：**
```
CardLayout注册: "Config" → Config组件 ✅
Tab标题i18n: "Config" → "配置" 🌐
查找时使用: "配置" → 找不到组件 ❌
```

## 🔧 解决方案

使用固定的索引映射数组 `CARD_KEYS`，通过 tab 索引获取对应的英文 key，而不是依赖可能被翻译的 tab 标题：

```java
// 修复后的代码
final String[] CARD_KEYS = {"DashBoard", "Config", "CodeTool"};
tabbedPane1.addChangeListener(e -> {
    int idx = tabbedPane1.getSelectedIndex();
    if (idx >= 0 && idx < CARD_KEYS.length) {
        CardLayout cl = (CardLayout) contentCards.getLayout();
        cl.show(contentCards, CARD_KEYS[idx]);  // 始终使用英文 key ✅
    }
});
```

## 📝 修改内容

### 变更文件
- `src/main/java/DetSql/DetSql.java` (7 行修改)

### 核心变更
1. 在 `ChangeListener` 中添加固定的 `CARD_KEYS` 数组
2. 通过 tab 索引 (`idx`) 获取对应的 CardLayout key
3. 确保 `CardLayout.show()` 使用正确的英文 key

## ✅ 测试结果

- ✅ 中文界面下配置页面正常显示
- ✅ 英文界面下配置页面正常显示
- ✅ 语言切换功能正常工作
- ✅ CodeTool 和 DashBoard 页面不受影响
- ✅ 所有复选框、文本框等配置项可正常使用

## 📸 测试截图

**修复前：** 点击"配置"按钮后显示空白
**修复后：** 配置面板正常显示所有选项

## 🎯 影响范围

- **影响模块：** UI 导航 (Tab 切换)
- **受益用户：** 所有使用非英文界面的用户
- **兼容性：** 无破坏性变更，向后兼容
- **性能影响：** 无

## 📚 相关链接

- Fixes #46
- 诊断过程详见 issue 讨论

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>